### PR TITLE
Implement setLogStream and getLogStream

### DIFF
--- a/openmmapi/include/PlumedForce.h
+++ b/openmmapi/include/PlumedForce.h
@@ -34,6 +34,7 @@
 
 #include "openmm/Context.h"
 #include "openmm/Force.h"
+#include <cstdio>
 #include <string>
 #include "internal/windowsExportPlumed.h"
 

--- a/openmmapi/include/PlumedForce.h
+++ b/openmmapi/include/PlumedForce.h
@@ -77,10 +77,19 @@ public:
     bool usesPeriodicBoundaryConditions() const {
         return false;
     }
+    /**
+     * Set the C stream of the PLUMED log. By default it is set to `stdout`.
+     */
+    void setLogStream(FILE* stream);
+    /**
+     * Get the C sream of the PLUMED log.
+     */
+    FILE* getLogStream() const;
 protected:
     OpenMM::ForceImpl* createImpl() const;
 private:
     std::string script;
+    FILE* logStream;
 };
 
 } // namespace PlumedPlugin

--- a/openmmapi/src/PlumedForce.cpp
+++ b/openmmapi/src/PlumedForce.cpp
@@ -29,6 +29,7 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.                                     *
  * -------------------------------------------------------------------------- */
 
+#include "openmm/OpenMMException.h"
 #include "PlumedForce.h"
 #include "internal/PlumedForceImpl.h"
 
@@ -36,11 +37,23 @@ using namespace PlumedPlugin;
 using namespace OpenMM;
 using namespace std;
 
-PlumedForce::PlumedForce(const string& script) : script(script) {
+PlumedForce::PlumedForce(const string& script) : script(script), logStream(stdout) {
 }
 
 const string& PlumedForce::getScript() const {
     return script;
+}
+
+void PlumedForce::setLogStream(FILE* stream) {
+
+    if (!stream)
+        throw OpenMMException("PlumedForce::setLogStream: the stream has to be open");
+
+    logStream = stream;
+}
+
+FILE* PlumedForce::getLogStream() const {
+    return logStream;
 }
 
 ForceImpl* PlumedForce::createImpl() const {

--- a/platforms/cuda/src/CudaPlumedKernels.cpp
+++ b/platforms/cuda/src/CudaPlumedKernels.cpp
@@ -145,6 +145,7 @@ void CudaCalcPlumedForceKernel::initialize(const System& system, const PlumedFor
     plumed_cmd(plumedmain, "setMDLengthUnits", &conversion);
     plumed_cmd(plumedmain, "setMDTimeUnits", &conversion);
     plumed_cmd(plumedmain, "setMDEngine", "OpenMM");
+    plumed_cmd(plumedmain, "setLog", force.getLogStream());
     int numParticles = system.getNumParticles();
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();

--- a/platforms/opencl/src/OpenCLPlumedKernels.cpp
+++ b/platforms/opencl/src/OpenCLPlumedKernels.cpp
@@ -105,6 +105,7 @@ void OpenCLCalcPlumedForceKernel::initialize(const System& system, const PlumedF
     plumed_cmd(plumedmain, "setMDLengthUnits", &conversion);
     plumed_cmd(plumedmain, "setMDTimeUnits", &conversion);
     plumed_cmd(plumedmain, "setMDEngine", "OpenMM");
+    plumed_cmd(plumedmain, "setLog", force.getLogStream());
     int numParticles = system.getNumParticles();
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();

--- a/platforms/reference/src/ReferencePlumedKernels.cpp
+++ b/platforms/reference/src/ReferencePlumedKernels.cpp
@@ -81,6 +81,7 @@ void ReferenceCalcPlumedForceKernel::initialize(const System& system, const Plum
     plumed_cmd(plumedmain, "setMDLengthUnits", &conversion);
     plumed_cmd(plumedmain, "setMDTimeUnits", &conversion);
     plumed_cmd(plumedmain, "setMDEngine", "OpenMM");
+    plumed_cmd(plumedmain, "setLog", force.getLogStream());
     int numParticles = system.getNumParticles();
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();


### PR DESCRIPTION
*PLUMED* writes the log to `stdout` by default, but It can be changed via its API (https://www.plumed.org/doc-v2.6/developer-doc/html/_how_to_plumed_your_m_d.html):
```c++
plumed_cmd(plumedmain, "setLog", stream);
```
This PR implements a corresponding functionality for *OpenMM-PLUMED* API:
```c++
void PlumedForce::setLogStream(FILE* stream);
FILE* PlumedForce::getLogStream() const;
```