### PR TITLE
Implement setRestart and getRestart

### DIFF
--- a/openmmapi/include/PlumedForce.h
+++ b/openmmapi/include/PlumedForce.h
@@ -86,11 +86,20 @@ public:
      * Get the C sream of the PLUMED log.
      */
     FILE* getLogStream() const;
+    /**
+     * Set PLUMED restarts. By default it is `false`.
+     */
+    void setRestart(bool restart);
+    /**
+     * Get PLUMED restart.
+     */
+    bool getRestart() const;
 protected:
     OpenMM::ForceImpl* createImpl() const;
 private:
     std::string script;
     FILE* logStream;
+    bool restart;
 };
 
 } // namespace PlumedPlugin

--- a/openmmapi/include/PlumedForce.h
+++ b/openmmapi/include/PlumedForce.h
@@ -87,11 +87,11 @@ public:
      */
     FILE* getLogStream() const;
     /**
-     * Set PLUMED restarts. By default it is `false`.
+     * Set the state of PLUMED restart (https://www.plumed.org/doc-master/user-doc/html/_r_e_s_t_a_r_t.html). By default it is `false`.
      */
     void setRestart(bool restart);
     /**
-     * Get PLUMED restart.
+     * Get the state of PLUMED restart.
      */
     bool getRestart() const;
 protected:

--- a/openmmapi/src/PlumedForce.cpp
+++ b/openmmapi/src/PlumedForce.cpp
@@ -37,7 +37,8 @@ using namespace PlumedPlugin;
 using namespace OpenMM;
 using namespace std;
 
-PlumedForce::PlumedForce(const string& script) : script(script), logStream(stdout) {
+PlumedForce::PlumedForce(const string& script) : script(script), logStream(stdout),
+    restart(false) {
 }
 
 const string& PlumedForce::getScript() const {
@@ -58,4 +59,12 @@ FILE* PlumedForce::getLogStream() const {
 
 ForceImpl* PlumedForce::createImpl() const {
     return new PlumedForceImpl(*this);
+}
+
+void PlumedForce::setRestart(bool restart_) {
+    restart = restart_;
+}
+
+bool PlumedForce::getRestart() const {
+    return restart;
 }

--- a/platforms/cuda/src/CudaPlumedKernels.cpp
+++ b/platforms/cuda/src/CudaPlumedKernels.cpp
@@ -150,6 +150,8 @@ void CudaCalcPlumedForceKernel::initialize(const System& system, const PlumedFor
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();
     plumed_cmd(plumedmain, "setTimestep", &dt);
+    int restart = force.getRestart();
+    plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);
     vector<char> scriptChars(force.getScript().size()+1);
     strcpy(&scriptChars[0], force.getScript().c_str());

--- a/platforms/opencl/src/OpenCLPlumedKernels.cpp
+++ b/platforms/opencl/src/OpenCLPlumedKernels.cpp
@@ -110,6 +110,8 @@ void OpenCLCalcPlumedForceKernel::initialize(const System& system, const PlumedF
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();
     plumed_cmd(plumedmain, "setTimestep", &dt);
+    int restart = force.getRestart();
+    plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);
     vector<char> scriptChars(force.getScript().size()+1);
     strcpy(&scriptChars[0], force.getScript().c_str());

--- a/platforms/reference/src/ReferencePlumedKernels.cpp
+++ b/platforms/reference/src/ReferencePlumedKernels.cpp
@@ -86,6 +86,8 @@ void ReferenceCalcPlumedForceKernel::initialize(const System& system, const Plum
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();
     plumed_cmd(plumedmain, "setTimestep", &dt);
+    int restart = force.getRestart();
+    plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);
     vector<char> scriptChars(force.getScript().size()+1);
     strcpy(&scriptChars[0], force.getScript().c_str());

--- a/serialization/src/PlumedForceProxy.cpp
+++ b/serialization/src/PlumedForceProxy.cpp
@@ -41,14 +41,16 @@ PlumedForceProxy::PlumedForceProxy() : SerializationProxy("PlumedForce") {
 }
 
 void PlumedForceProxy::serialize(const void* object, SerializationNode& node) const {
-    node.setIntProperty("version", 1);
+    node.setIntProperty("version", 2);
     const PlumedForce& force = *reinterpret_cast<const PlumedForce*>(object);
     node.setStringProperty("script", force.getScript());
+    node.setBoolProperty("restart", force.getRestart());
 }
 
 void* PlumedForceProxy::deserialize(const SerializationNode& node) const {
-    if (node.getIntProperty("version") != 1)
+    if (node.getIntProperty("version") != 2)
         throw OpenMMException("Unsupported version number");
     PlumedForce* force = new PlumedForce(node.getStringProperty("script"));
+    force->setRestart(node.getBoolProperty("restart"));
     return force;
 }


### PR DESCRIPTION
*PLUMED* does not restart a simulation by default, but this can be changed via its API (https://www.plumed.org/doc-v2.6/developer-doc/html/_how_to_plumed_your_m_d.html):
```c++
plumed_cmd(plumedmain, "setRestart", &restart);
```
This PR implements a corresponding functionality for *OpenMM-PLUMED* API:
```c++
void PlumedForce::setRestart(bool restart);
bool PlumedForce::getRestart() const;
```