### PR TITLE
add isScriptFile argument to allow continuation lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Simply create a `PlumedForce` object, passing the PLUMED control script as an ar
 constructor, then add it to your `System`.  For example,
 
 ```Python
+from openmmplumed import PlumedForce
+
 script = """
 d: DISTANCE ATOMS=1,10
 METAD ARG=d SIGMA=0.2 HEIGHT=0.3 PACE=500"""

--- a/openmmapi/include/PlumedForce.h
+++ b/openmmapi/include/PlumedForce.h
@@ -64,12 +64,19 @@ public:
      * Create a PlumedForce.
      *
      * @param script    the PLUMED input script
+     * @param isScriptFile  whether the script parameter is a file name or the script content
      */
-    PlumedForce(const std::string& script);
+    PlumedForce(const std::string& script, bool isScriptFile=false);
     /**
      * Get the PLUMED input script
      */
     const std::string& getScript() const;
+    /**
+     * Get whether the script is a file
+     */
+    bool getScriptFile() const {
+	return isScriptFile;
+    }
     /**
      * Returns true if the force uses periodic boundary conditions and false otherwise. Your force should implement this
      * method appropriately to ensure that `System.usesPeriodicBoundaryConditions()` works for all systems containing
@@ -98,6 +105,7 @@ protected:
     OpenMM::ForceImpl* createImpl() const;
 private:
     std::string script;
+    bool isScriptFile;
     FILE* logStream;
     bool restart;
 };

--- a/openmmapi/src/PlumedForce.cpp
+++ b/openmmapi/src/PlumedForce.cpp
@@ -37,8 +37,9 @@ using namespace PlumedPlugin;
 using namespace OpenMM;
 using namespace std;
 
-PlumedForce::PlumedForce(const string& script) : script(script), logStream(stdout),
-    restart(false) {
+PlumedForce::PlumedForce(const string& script, bool isScriptFile) : 
+    script(script), isScriptFile(isScriptFile),
+    logStream(stdout), restart(false) {
 }
 
 const string& PlumedForce::getScript() const {

--- a/platforms/cuda/src/CudaPlumedKernels.cpp
+++ b/platforms/cuda/src/CudaPlumedKernels.cpp
@@ -153,13 +153,19 @@ void CudaCalcPlumedForceKernel::initialize(const System& system, const PlumedFor
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);
+
     vector<char> scriptChars(force.getScript().size()+1);
     strcpy(&scriptChars[0], force.getScript().c_str());
-    char* line = strtok(&scriptChars[0], "\r\n");
-    while (line != NULL) {
-        plumed_cmd(plumedmain, "readInputLine", line);
-        line = strtok(NULL, "\r\n");
+    if(force.getScriptFile()) {
+        plumed_cmd(plumedmain, "read", &scriptChars[0]);
+    } else {
+        char* line = strtok(&scriptChars[0], "\r\n");
+        while (line != NULL) {
+            plumed_cmd(plumedmain, "readInputLine", line);
+            line = strtok(NULL, "\r\n");
+        }
     }
+
     usesPeriodic = system.usesPeriodicBoundaryConditions();
 
     // Record the particle masses.

--- a/platforms/opencl/src/OpenCLPlumedKernels.cpp
+++ b/platforms/opencl/src/OpenCLPlumedKernels.cpp
@@ -113,13 +113,19 @@ void OpenCLCalcPlumedForceKernel::initialize(const System& system, const PlumedF
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);
+
     vector<char> scriptChars(force.getScript().size()+1);
     strcpy(&scriptChars[0], force.getScript().c_str());
-    char* line = strtok(&scriptChars[0], "\r\n");
-    while (line != NULL) {
-        plumed_cmd(plumedmain, "readInputLine", line);
-        line = strtok(NULL, "\r\n");
+    if(force.getScriptFile()) {
+        plumed_cmd(plumedmain, "read", &scriptChars[0]);
+    } else {
+        char* line = strtok(&scriptChars[0], "\r\n");
+        while (line != NULL) {
+            plumed_cmd(plumedmain, "readInputLine", line);
+            line = strtok(NULL, "\r\n");
+        }
     }
+
     usesPeriodic = system.usesPeriodicBoundaryConditions();
 
     // Record the particle masses.

--- a/platforms/reference/src/ReferencePlumedKernels.cpp
+++ b/platforms/reference/src/ReferencePlumedKernels.cpp
@@ -89,13 +89,19 @@ void ReferenceCalcPlumedForceKernel::initialize(const System& system, const Plum
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);
+
     vector<char> scriptChars(force.getScript().size()+1);
     strcpy(&scriptChars[0], force.getScript().c_str());
-    char* line = strtok(&scriptChars[0], "\r\n");
-    while (line != NULL) {
-        plumed_cmd(plumedmain, "readInputLine", line);
-        line = strtok(NULL, "\r\n");
+    if(force.getScriptFile()) {
+        plumed_cmd(plumedmain, "read", &scriptChars[0]);
+    } else {
+        char* line = strtok(&scriptChars[0], "\r\n");
+        while (line != NULL) {
+            plumed_cmd(plumedmain, "readInputLine", line);
+            line = strtok(NULL, "\r\n");
+        }
     }
+
     usesPeriodic = system.usesPeriodicBoundaryConditions();
 
     // Record the particle masses.

--- a/python/plumedplugin.i
+++ b/python/plumedplugin.i
@@ -22,8 +22,9 @@ namespace PlumedPlugin {
 
 class PlumedForce : public OpenMM::Force {
 public:
-    PlumedForce(const std::string& script);
+    PlumedForce(const std::string& script, bool isScriptFile=false);
     const std::string& getScript() const;
+    const bool getScriptFile() const;
 };
 
 }


### PR DESCRIPTION
Here I added a flag to load the whole script file (as opposed as script text). This is a strategy to allow continuation lines (which don't work when loading script line-wise)  https://github.com/openmm/openmm-plumed/issues/19 .

 