### PR TITLE
Implement setTemperature and getTemperature

### DIFF
--- a/openmmapi/include/PlumedForce.h
+++ b/openmmapi/include/PlumedForce.h
@@ -79,12 +79,12 @@ public:
         return false;
     }
     /**
-     * Set temperature. A negative value means undefined and not passed to PLUMED.
+     * Set temperature, measured in Kelvin. A negative value means undefined and not passed to PLUMED.
      * By default it is set to -1.
      */
-    void setTemperature(double KbT);
+    void setTemperature(double temperature);
     /**
-     * Get temperature.
+     * Get temperature, measured in Kelvin.
      */
     double getTemperature() const;
     /**

--- a/openmmapi/include/PlumedForce.h
+++ b/openmmapi/include/PlumedForce.h
@@ -79,6 +79,15 @@ public:
         return false;
     }
     /**
+     * Set kT value (kJ/mol). A negative value means undefined and not passed to PLUMED.
+     * By default it is set to -1.
+     */
+    void setKbT(double KbT);
+    /**
+     * Get kT value (kJ/mol).
+     */
+    double getKbT() const;
+    /**
      * Set the C stream of the PLUMED log. By default it is set to `stdout`.
      */
     void setLogStream(FILE* stream);
@@ -98,6 +107,7 @@ protected:
     OpenMM::ForceImpl* createImpl() const;
 private:
     std::string script;
+    double kT;
     FILE* logStream;
     bool restart;
 };

--- a/openmmapi/include/PlumedForce.h
+++ b/openmmapi/include/PlumedForce.h
@@ -79,14 +79,14 @@ public:
         return false;
     }
     /**
-     * Set kT value (kJ/mol). A negative value means undefined and not passed to PLUMED.
+     * Set temperature. A negative value means undefined and not passed to PLUMED.
      * By default it is set to -1.
      */
-    void setKbT(double KbT);
+    void setTemperature(double KbT);
     /**
-     * Get kT value (kJ/mol).
+     * Get temperature.
      */
-    double getKbT() const;
+    double getTemperature() const;
     /**
      * Set the C stream of the PLUMED log. By default it is set to `stdout`.
      */
@@ -107,7 +107,7 @@ protected:
     OpenMM::ForceImpl* createImpl() const;
 private:
     std::string script;
-    double kT;
+    double temperature;
     FILE* logStream;
     bool restart;
 };

--- a/openmmapi/src/PlumedForce.cpp
+++ b/openmmapi/src/PlumedForce.cpp
@@ -37,7 +37,7 @@ using namespace PlumedPlugin;
 using namespace OpenMM;
 using namespace std;
 
-PlumedForce::PlumedForce(const string& script) : script(script), kT(-1),
+PlumedForce::PlumedForce(const string& script) : script(script), temperature(-1),
     logStream(stdout), restart(false) {
 }
 
@@ -45,12 +45,12 @@ const string& PlumedForce::getScript() const {
     return script;
 }
 
-void PlumedForce::setKbT(double kT_) {
-    kT = kT_;
+void PlumedForce::setTemperature(double temperature_) {
+    temperature = temperature_;
 }
 
-double PlumedForce::getKbT() const {
-    return kT;
+double PlumedForce::getTemperature() const {
+    return temperature;
 }
 
 void PlumedForce::setLogStream(FILE* stream) {

--- a/openmmapi/src/PlumedForce.cpp
+++ b/openmmapi/src/PlumedForce.cpp
@@ -37,12 +37,20 @@ using namespace PlumedPlugin;
 using namespace OpenMM;
 using namespace std;
 
-PlumedForce::PlumedForce(const string& script) : script(script), logStream(stdout),
-    restart(false) {
+PlumedForce::PlumedForce(const string& script) : script(script), kT(-1),
+    logStream(stdout), restart(false) {
 }
 
 const string& PlumedForce::getScript() const {
     return script;
+}
+
+void PlumedForce::setKbT(double kT_) {
+    kT = kT_;
+}
+
+double PlumedForce::getKbT() const {
+    return kT;
 }
 
 void PlumedForce::setLogStream(FILE* stream) {

--- a/platforms/cuda/src/CudaPlumedKernels.cpp
+++ b/platforms/cuda/src/CudaPlumedKernels.cpp
@@ -150,6 +150,9 @@ void CudaCalcPlumedForceKernel::initialize(const System& system, const PlumedFor
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();
     plumed_cmd(plumedmain, "setTimestep", &dt);
+    double kT = force.getKbT();
+    if (kT >= 0.0)
+        plumed_cmd(plumedmain,"setKbT",&kT);
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);

--- a/platforms/cuda/src/CudaPlumedKernels.cpp
+++ b/platforms/cuda/src/CudaPlumedKernels.cpp
@@ -36,6 +36,7 @@
 #include "openmm/internal/ThreadPool.h"
 #include "openmm/cuda/CudaBondedUtilities.h"
 #include "openmm/cuda/CudaForceInfo.h"
+#include "openmm/reference/SimTKOpenMMRealType.h"
 #include <cstring>
 #include <map>
 
@@ -150,9 +151,9 @@ void CudaCalcPlumedForceKernel::initialize(const System& system, const PlumedFor
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();
     plumed_cmd(plumedmain, "setTimestep", &dt);
-    double kT = force.getKbT();
+    double kT = force.getTemperature() * BOLTZ;
     if (kT >= 0.0)
-        plumed_cmd(plumedmain,"setKbT",&kT);
+        plumed_cmd(plumedmain, "setKbT", &kT);
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);

--- a/platforms/cuda/tests/TestCudaPlumedForce.cpp
+++ b/platforms/cuda/tests/TestCudaPlumedForce.cpp
@@ -40,6 +40,7 @@
 #include "openmm/LangevinIntegrator.h"
 #include "openmm/Platform.h"
 #include "openmm/System.h"
+#include "openmm/reference/SimTKOpenMMRealType.h"
 #include <iostream>
 #include <string>
 #include <vector>
@@ -118,6 +119,57 @@ void testMetadynamics() {
     }
 }
 
+void testWellTemperedMetadynamics() {
+
+    // Simulation parameters
+    const double height0 = 0.1;
+    const double sigma = 0.5;
+    const double temperatue = 300.0;
+    const double delta_temperature = 30.0;
+    // Note: BIASFACTOR = temperature + delta_temperature / temperature,
+    //       so PLUMED has to know a temperature to compupute
+    //       delta_temperature from BIASFACTOR
+    //       (https://www.plumed.org/doc-master/user-doc/html/belfast-6.html).
+    const string script =
+        "p: POSITION ATOM=1\n"
+        "METAD ARG=p.x HEIGHT=0.1 SIGMA=0.5 BIASFACTOR=1.1 PACE=1";
+
+    // Create a system within a one dimensional harmonic potential
+    System system;
+    system.addParticle(1.0);
+    CustomExternalForce* external = new CustomExternalForce("x^2");
+    external->addParticle(0);
+    system.addForce(external);
+
+    // Create a well-tempered metadynamics simulation
+    PlumedForce* plumed = new PlumedForce(script);
+    plumed->setTemperature(temperatue); // This is tested here!
+    system.addForce(plumed);
+    LangevinIntegrator integ(temperatue, 1.0, 1.0);
+    Platform& platform = Platform::getPlatformByName("CUDA");
+    Context context(system, integ, platform);
+    context.setPositions({Vec3()});
+
+    // Run the simulation and compare potential energy
+    vector<double> centers, heights;
+    for (int i = 0; i < 100; i++) {
+        integ.step(1);
+        State state = context.getState(State::Positions | State::Energy);
+        double x = state.getPositions()[0][0];
+
+        // Compute bias
+        double bias = 0;
+        for (int j = 0; j < centers.size(); j++)
+            bias += heights[j]*exp(-(x-centers[j])*(x-centers[j])/(2*sigma*sigma));
+        if (i > 0) {
+            centers.push_back(x);
+            heights.push_back(height0*exp(-bias/(delta_temperature*BOLTZ)));
+        }
+
+        ASSERT_EQUAL_TOL(bias + x*x, state.getPotentialEnergy(), 1e-3);
+    }
+}
+
 int main(int argc, char* argv[]) {
     try {
         registerPlumedCudaKernelFactories();
@@ -125,6 +177,7 @@ int main(int argc, char* argv[]) {
             Platform::getPlatformByName("CUDA").setPropertyDefaultValue("CudaPrecision", string(argv[1]));
         testForce();
         testMetadynamics();
+        testWellTemperedMetadynamics();
     }
     catch(const std::exception& e) {
         std::cout << "exception: " << e.what() << std::endl;

--- a/platforms/opencl/src/OpenCLPlumedKernels.cpp
+++ b/platforms/opencl/src/OpenCLPlumedKernels.cpp
@@ -110,6 +110,9 @@ void OpenCLCalcPlumedForceKernel::initialize(const System& system, const PlumedF
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();
     plumed_cmd(plumedmain, "setTimestep", &dt);
+    double kT = force.getKbT();
+    if (kT >= 0.0)
+        plumed_cmd(plumedmain,"setKbT",&kT);
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);

--- a/platforms/opencl/src/OpenCLPlumedKernels.cpp
+++ b/platforms/opencl/src/OpenCLPlumedKernels.cpp
@@ -35,6 +35,7 @@
 #include "openmm/internal/ContextImpl.h"
 #include "openmm/opencl/OpenCLBondedUtilities.h"
 #include "openmm/opencl/OpenCLForceInfo.h"
+#include "openmm/reference/SimTKOpenMMRealType.h"
 #include <cstring>
 #include <map>
 
@@ -110,9 +111,9 @@ void OpenCLCalcPlumedForceKernel::initialize(const System& system, const PlumedF
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();
     plumed_cmd(plumedmain, "setTimestep", &dt);
-    double kT = force.getKbT();
+    double kT = force.getTemperature() * BOLTZ;
     if (kT >= 0.0)
-        plumed_cmd(plumedmain,"setKbT",&kT);
+        plumed_cmd(plumedmain, "setKbT", &kT);
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);

--- a/platforms/reference/src/ReferencePlumedKernels.cpp
+++ b/platforms/reference/src/ReferencePlumedKernels.cpp
@@ -86,6 +86,9 @@ void ReferenceCalcPlumedForceKernel::initialize(const System& system, const Plum
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();
     plumed_cmd(plumedmain, "setTimestep", &dt);
+    double kT = force.getKbT();
+    if (kT >= 0.0)
+        plumed_cmd(plumedmain,"setKbT",&kT);
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);

--- a/platforms/reference/src/ReferencePlumedKernels.cpp
+++ b/platforms/reference/src/ReferencePlumedKernels.cpp
@@ -36,6 +36,7 @@
 #include "openmm/internal/ContextImpl.h"
 #include "openmm/reference/RealVec.h"
 #include "openmm/reference/ReferencePlatform.h"
+#include "openmm/reference/SimTKOpenMMRealType.h"
 #include <cstring>
 
 using namespace PlumedPlugin;
@@ -86,9 +87,9 @@ void ReferenceCalcPlumedForceKernel::initialize(const System& system, const Plum
     plumed_cmd(plumedmain, "setNatoms", &numParticles);
     double dt = contextImpl.getIntegrator().getStepSize();
     plumed_cmd(plumedmain, "setTimestep", &dt);
-    double kT = force.getKbT();
+    double kT = force.getTemperature() * BOLTZ;
     if (kT >= 0.0)
-        plumed_cmd(plumedmain,"setKbT",&kT);
+        plumed_cmd(plumedmain, "setKbT", &kT);
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);

--- a/platforms/reference/tests/TestReferencePlumedForce.cpp
+++ b/platforms/reference/tests/TestReferencePlumedForce.cpp
@@ -40,6 +40,7 @@
 #include "openmm/LangevinIntegrator.h"
 #include "openmm/Platform.h"
 #include "openmm/System.h"
+#include "openmm/reference/SimTKOpenMMRealType.h"
 #include <iostream>
 #include <string>
 #include <vector>
@@ -118,11 +119,63 @@ void testMetadynamics() {
     }
 }
 
+void testWellTemperedMetadynamics() {
+
+    // Simulation parameters
+    const double height0 = 0.1;
+    const double sigma = 0.5;
+    const double temperatue = 300.0;
+    const double delta_temperature = 30.0;
+    // Note: BIASFACTOR = temperature + delta_temperature / temperature,
+    //       so PLUMED has to know a temperature to compupute
+    //       delta_temperature from BIASFACTOR
+    //       (https://www.plumed.org/doc-master/user-doc/html/belfast-6.html).
+    const string script =
+        "p: POSITION ATOM=1\n"
+        "METAD ARG=p.x HEIGHT=0.1 SIGMA=0.5 BIASFACTOR=1.1 PACE=1";
+
+    // Create a system within a one dimensional harmonic potential
+    System system;
+    system.addParticle(1.0);
+    CustomExternalForce* external = new CustomExternalForce("x^2");
+    external->addParticle(0);
+    system.addForce(external);
+
+    // Create a well-tempered metadynamics simulation
+    PlumedForce* plumed = new PlumedForce(script);
+    plumed->setTemperature(temperatue); // This is tested here!
+    system.addForce(plumed);
+    LangevinIntegrator integ(temperatue, 1.0, 1.0);
+    Platform& platform = Platform::getPlatformByName("Reference");
+    Context context(system, integ, platform);
+    context.setPositions({Vec3()});
+
+    // Run the simulation and compare potential energy
+    vector<double> centers, heights;
+    for (int i = 0; i < 100; i++) {
+        integ.step(1);
+        State state = context.getState(State::Positions | State::Energy);
+        double x = state.getPositions()[0][0];
+
+        // Compute bias
+        double bias = 0;
+        for (int j = 0; j < centers.size(); j++)
+            bias += heights[j]*exp(-(x-centers[j])*(x-centers[j])/(2*sigma*sigma));
+        if (i > 0) {
+            centers.push_back(x);
+            heights.push_back(height0*exp(-bias/(delta_temperature*BOLTZ)));
+        }
+
+        ASSERT_EQUAL_TOL(bias + x*x, state.getPotentialEnergy(), 1e-3);
+    }
+}
+
 int main() {
     try {
         registerPlumedReferenceKernelFactories();
         testForce();
         testMetadynamics();
+        testWellTemperedMetadynamics();
     }
     catch(const std::exception& e) {
         std::cout << "exception: " << e.what() << std::endl;

--- a/serialization/src/PlumedForceProxy.cpp
+++ b/serialization/src/PlumedForceProxy.cpp
@@ -41,16 +41,18 @@ PlumedForceProxy::PlumedForceProxy() : SerializationProxy("PlumedForce") {
 }
 
 void PlumedForceProxy::serialize(const void* object, SerializationNode& node) const {
-    node.setIntProperty("version", 2);
+    node.setIntProperty("version", 3);
     const PlumedForce& force = *reinterpret_cast<const PlumedForce*>(object);
     node.setStringProperty("script", force.getScript());
+    node.setDoubleProperty("kT", force.getKbT());
     node.setBoolProperty("restart", force.getRestart());
 }
 
 void* PlumedForceProxy::deserialize(const SerializationNode& node) const {
-    if (node.getIntProperty("version") != 2)
+    if (node.getIntProperty("version") != 3)
         throw OpenMMException("Unsupported version number");
     PlumedForce* force = new PlumedForce(node.getStringProperty("script"));
+    force->setKbT(node.getDoubleProperty("kT"));
     force->setRestart(node.getBoolProperty("restart"));
     return force;
 }

--- a/serialization/src/PlumedForceProxy.cpp
+++ b/serialization/src/PlumedForceProxy.cpp
@@ -49,10 +49,15 @@ void PlumedForceProxy::serialize(const void* object, SerializationNode& node) co
 }
 
 void* PlumedForceProxy::deserialize(const SerializationNode& node) const {
-    if (node.getIntProperty("version") != 3)
+    const int version = node.getIntProperty("version");
+    if (version < 1 || version > 3)
         throw OpenMMException("Unsupported version number");
+
     PlumedForce* force = new PlumedForce(node.getStringProperty("script"));
-    force->setTemperature(node.getDoubleProperty("temperature"));
-    force->setRestart(node.getBoolProperty("restart"));
+    if (version > 1)
+        force->setRestart(node.getBoolProperty("restart"));
+    if (version > 2)
+        force->setTemperature(node.getDoubleProperty("temperature"));
+
     return force;
 }

--- a/serialization/src/PlumedForceProxy.cpp
+++ b/serialization/src/PlumedForceProxy.cpp
@@ -44,7 +44,7 @@ void PlumedForceProxy::serialize(const void* object, SerializationNode& node) co
     node.setIntProperty("version", 3);
     const PlumedForce& force = *reinterpret_cast<const PlumedForce*>(object);
     node.setStringProperty("script", force.getScript());
-    node.setDoubleProperty("kT", force.getKbT());
+    node.setDoubleProperty("temperature", force.getTemperature());
     node.setBoolProperty("restart", force.getRestart());
 }
 
@@ -52,7 +52,7 @@ void* PlumedForceProxy::deserialize(const SerializationNode& node) const {
     if (node.getIntProperty("version") != 3)
         throw OpenMMException("Unsupported version number");
     PlumedForce* force = new PlumedForce(node.getStringProperty("script"));
-    force->setKbT(node.getDoubleProperty("kT"));
+    force->setTemperature(node.getDoubleProperty("temperature"));
     force->setRestart(node.getBoolProperty("restart"));
     return force;
 }

--- a/serialization/tests/TestSerializePlumedForce.cpp
+++ b/serialization/tests/TestSerializePlumedForce.cpp
@@ -47,7 +47,11 @@ void testSerialization() {
 
     string script = "d: DISTANCE ATOMS=1,3\n"
                     "BIASVALUE ARG=d";
+    bool restart = true;
+    double temperature = 42.0;
     PlumedForce force(script);
+    force.setRestart(restart);
+    force.setTemperature(temperature);
 
     // Serialize and then deserialize it.
 
@@ -59,6 +63,8 @@ void testSerialization() {
 
     PlumedForce& force2 = *copy;
     ASSERT_EQUAL(script, force2.getScript());
+    ASSERT_EQUAL(restart, force2.getRestart());
+    ASSERT_EQUAL(temperature, force2.getTemperature());
 }
 
 int main() {


### PR DESCRIPTION
*PLUMED* allows to pass *kT* value via its API (https://www.plumed.org/doc-v2.6/developer-doc/html/_how_to_plumed_your_m_d.html):
```c++
plumed_cmd(plumedmain, "setKbT", &kT);
```
This PR implements a corresponding functionality for *OpenMM-PLUMED* API:
```c++
void PlumedForce::setTemperature(double temperature);
double PlumedForce::getTemperature() const;
```