### PR TITLE
Use "readInputLines" to read PLUMED input

### DIFF
--- a/platforms/cuda/src/CudaPlumedKernels.cpp
+++ b/platforms/cuda/src/CudaPlumedKernels.cpp
@@ -159,12 +159,19 @@ void CudaCalcPlumedForceKernel::initialize(const System& system, const PlumedFor
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);
-    vector<char> scriptChars(force.getScript().size()+1);
-    strcpy(&scriptChars[0], force.getScript().c_str());
-    char* line = strtok(&scriptChars[0], "\r\n");
-    while (line != NULL) {
-        plumed_cmd(plumedmain, "readInputLine", line);
-        line = strtok(NULL, "\r\n");
+    if(apiVersion > 7) {
+        plumed_cmd(plumedmain, "readInputLines", force.getScript().c_str());
+    } else {
+        // NOTE: the comments and line continuation does not works
+        //       (https://github.com/plumed/plumed2/issues/571)
+        // TODO: remove this when PLUMED 2.6 support is dropped
+        vector<char> scriptChars(force.getScript().size()+1);
+        strcpy(&scriptChars[0], force.getScript().c_str());
+        char* line = strtok(&scriptChars[0], "\r\n");
+        while (line != NULL) {
+            plumed_cmd(plumedmain, "readInputLine", line);
+            line = strtok(NULL, "\r\n");
+        }
     }
     usesPeriodic = system.usesPeriodicBoundaryConditions();
 

--- a/platforms/cuda/tests/TestCudaPlumedForce.cpp
+++ b/platforms/cuda/tests/TestCudaPlumedForce.cpp
@@ -254,7 +254,7 @@ void testScript() {
                           "PRINT ...\n"
                           "\n"
                           "  ARG=p.x,p.y,p.z\n"
-                          "  # A comment in the middle"
+                          "  # A comment in the middle\n"
                           "  STRIDE=10\n"
                           "...";
     PlumedForce* plumed = new PlumedForce(script);
@@ -264,6 +264,8 @@ void testScript() {
     LangevinIntegrator integ(300.0, 1.0, 1.0);
     Platform& platform = Platform::getPlatformByName("CUDA");
     Context context(system, integ, platform);
+
+    // If the parser fails, an exception is thrown during the context creation
 }
 
 int main(int argc, char* argv[]) {

--- a/platforms/cuda/tests/TestCudaPlumedForce.cpp
+++ b/platforms/cuda/tests/TestCudaPlumedForce.cpp
@@ -240,6 +240,32 @@ void testMassesCharges() {
     ASSERT_EQUAL(charge, -2.1);
 }
 
+void testScript() {
+
+    // Create a system
+    System system;
+    system.addParticle(0);
+
+    // Setup PLUMED
+    const string script = "#Comment\n"
+                          "p: POSITION ATOM=1\n"
+                          "\n"
+                          "# More comments and empty lines\n"
+                          "PRINT ...\n"
+                          "\n"
+                          "  ARG=p.x,p.y,p.z\n"
+                          "  # A comment in the middle"
+                          "  STRIDE=10\n"
+                          "...";
+    PlumedForce* plumed = new PlumedForce(script);
+    system.addForce(plumed);
+
+    // Setup simulation
+    LangevinIntegrator integ(300.0, 1.0, 1.0);
+    Platform& platform = Platform::getPlatformByName("CUDA");
+    Context context(system, integ, platform);
+}
+
 int main(int argc, char* argv[]) {
     try {
         registerPlumedCudaKernelFactories();
@@ -249,6 +275,7 @@ int main(int argc, char* argv[]) {
         testMetadynamics();
         testWellTemperedMetadynamics();
         testMassesCharges();
+        testScript();
     }
     catch(const std::exception& e) {
         std::cout << "exception: " << e.what() << std::endl;

--- a/platforms/opencl/src/OpenCLPlumedKernels.cpp
+++ b/platforms/opencl/src/OpenCLPlumedKernels.cpp
@@ -119,12 +119,19 @@ void OpenCLCalcPlumedForceKernel::initialize(const System& system, const PlumedF
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);
-    vector<char> scriptChars(force.getScript().size()+1);
-    strcpy(&scriptChars[0], force.getScript().c_str());
-    char* line = strtok(&scriptChars[0], "\r\n");
-    while (line != NULL) {
-        plumed_cmd(plumedmain, "readInputLine", line);
-        line = strtok(NULL, "\r\n");
+    if(apiVersion > 7) {
+        plumed_cmd(plumedmain, "readInputLines", force.getScript().c_str());
+    } else {
+        // NOTE: the comments and line continuation does not works
+        //       (https://github.com/plumed/plumed2/issues/571)
+        // TODO: remove this when PLUMED 2.6 support is dropped
+        vector<char> scriptChars(force.getScript().size()+1);
+        strcpy(&scriptChars[0], force.getScript().c_str());
+        char* line = strtok(&scriptChars[0], "\r\n");
+        while (line != NULL) {
+            plumed_cmd(plumedmain, "readInputLine", line);
+            line = strtok(NULL, "\r\n");
+        }
     }
     usesPeriodic = system.usesPeriodicBoundaryConditions();
 

--- a/platforms/opencl/tests/TestOpenCLPlumedForce.cpp
+++ b/platforms/opencl/tests/TestOpenCLPlumedForce.cpp
@@ -254,7 +254,7 @@ void testScript() {
                           "PRINT ...\n"
                           "\n"
                           "  ARG=p.x,p.y,p.z\n"
-                          "  # A comment in the middle"
+                          "  # A comment in the middle\n"
                           "  STRIDE=10\n"
                           "...";
     PlumedForce* plumed = new PlumedForce(script);
@@ -264,6 +264,8 @@ void testScript() {
     LangevinIntegrator integ(300.0, 1.0, 1.0);
     Platform& platform = Platform::getPlatformByName("OpenCL");
     Context context(system, integ, platform);
+
+    // If the parser fails, an exception is thrown during the context creation
 }
 
 int main(int argc, char* argv[]) {

--- a/platforms/opencl/tests/TestOpenCLPlumedForce.cpp
+++ b/platforms/opencl/tests/TestOpenCLPlumedForce.cpp
@@ -240,6 +240,32 @@ void testMassesCharges() {
     ASSERT_EQUAL(charge, -2.1);
 }
 
+void testScript() {
+
+    // Create a system
+    System system;
+    system.addParticle(0);
+
+    // Setup PLUMED
+    const string script = "#Comment\n"
+                          "p: POSITION ATOM=1\n"
+                          "\n"
+                          "# More comments and empty lines\n"
+                          "PRINT ...\n"
+                          "\n"
+                          "  ARG=p.x,p.y,p.z\n"
+                          "  # A comment in the middle"
+                          "  STRIDE=10\n"
+                          "...";
+    PlumedForce* plumed = new PlumedForce(script);
+    system.addForce(plumed);
+
+    // Setup simulation
+    LangevinIntegrator integ(300.0, 1.0, 1.0);
+    Platform& platform = Platform::getPlatformByName("OpenCL");
+    Context context(system, integ, platform);
+}
+
 int main(int argc, char* argv[]) {
     try {
         registerPlumedOpenCLKernelFactories();
@@ -249,6 +275,8 @@ int main(int argc, char* argv[]) {
         testMetadynamics();
         testWellTemperedMetadynamics();
         testMassesCharges();
+        testScript();
+
     }
     catch(const std::exception& e) {
         std::cout << "exception: " << e.what() << std::endl;

--- a/platforms/reference/src/ReferencePlumedKernels.cpp
+++ b/platforms/reference/src/ReferencePlumedKernels.cpp
@@ -93,12 +93,19 @@ void ReferenceCalcPlumedForceKernel::initialize(const System& system, const Plum
     int restart = force.getRestart();
     plumed_cmd(plumedmain, "setRestart", &restart);
     plumed_cmd(plumedmain, "init", NULL);
-    vector<char> scriptChars(force.getScript().size()+1);
-    strcpy(&scriptChars[0], force.getScript().c_str());
-    char* line = strtok(&scriptChars[0], "\r\n");
-    while (line != NULL) {
-        plumed_cmd(plumedmain, "readInputLine", line);
-        line = strtok(NULL, "\r\n");
+    if(apiVersion > 7) {
+        plumed_cmd(plumedmain, "readInputLines", force.getScript().c_str());
+    } else {
+        // NOTE: the comments and line continuation does not works
+        //       (https://github.com/plumed/plumed2/issues/571)
+        // TODO: remove this when PLUMED 2.6 support is dropped
+        vector<char> scriptChars(force.getScript().size()+1);
+        strcpy(&scriptChars[0], force.getScript().c_str());
+        char* line = strtok(&scriptChars[0], "\r\n");
+        while (line != NULL) {
+            plumed_cmd(plumedmain, "readInputLine", line);
+            line = strtok(NULL, "\r\n");
+        }
     }
     usesPeriodic = system.usesPeriodicBoundaryConditions();
 

--- a/platforms/reference/tests/TestReferencePlumedForce.cpp
+++ b/platforms/reference/tests/TestReferencePlumedForce.cpp
@@ -240,6 +240,32 @@ void testMassesCharges() {
     ASSERT_EQUAL(charge, -2.1);
 }
 
+void testScript() {
+
+    // Create a system
+    System system;
+    system.addParticle(0);
+
+    // Setup PLUMED
+    const string script = "#Comment\n"
+                          "p: POSITION ATOM=1\n"
+                          "\n"
+                          "# More comments and empty lines\n"
+                          "PRINT ...\n"
+                          "\n"
+                          "  ARG=p.x,p.y,p.z\n"
+                          "  # A comment in the middle"
+                          "  STRIDE=10\n"
+                          "...";
+    PlumedForce* plumed = new PlumedForce(script);
+    system.addForce(plumed);
+
+    // Setup simulation
+    LangevinIntegrator integ(300.0, 1.0, 1.0);
+    Platform& platform = Platform::getPlatformByName("Reference");
+    Context context(system, integ, platform);
+}
+
 int main() {
     try {
         registerPlumedReferenceKernelFactories();
@@ -247,6 +273,7 @@ int main() {
         testMetadynamics();
         testWellTemperedMetadynamics();
         testMassesCharges();
+        testScript();
     }
     catch(const std::exception& e) {
         std::cout << "exception: " << e.what() << std::endl;

--- a/platforms/reference/tests/TestReferencePlumedForce.cpp
+++ b/platforms/reference/tests/TestReferencePlumedForce.cpp
@@ -254,7 +254,7 @@ void testScript() {
                           "PRINT ...\n"
                           "\n"
                           "  ARG=p.x,p.y,p.z\n"
-                          "  # A comment in the middle"
+                          "  # A comment in the middle\n"
                           "  STRIDE=10\n"
                           "...";
     PlumedForce* plumed = new PlumedForce(script);
@@ -264,6 +264,8 @@ void testScript() {
     LangevinIntegrator integ(300.0, 1.0, 1.0);
     Platform& platform = Platform::getPlatformByName("Reference");
     Context context(system, integ, platform);
+
+    // If the parser fails, an exception is thrown during the context creation
 }
 
 int main() {


### PR DESCRIPTION
Integrate the changes of https://github.com/plumed/plumed2/pull/583 to fix issue of the PLUME input parsing (https://github.com/plumed/plumed2/issues/571).

- [x]  Use `readInputLines` according to https://github.com/plumed/plumed2/issues/571#issuecomment-642708953
- [x] Add tests