### PR TITLE
Fix type of argument to plumed_cmd

### DIFF
--- a/platforms/cuda/src/CudaPlumedKernels.cpp
+++ b/platforms/cuda/src/CudaPlumedKernels.cpp
@@ -236,7 +236,7 @@ void CudaCalcPlumedForceKernel::executeOnWorkerThread() {
         plumed_cmd(plumedmain, "setBox", &boxVectors[0][0]);
     }
     double virial[9];
-    plumed_cmd(plumedmain, "setVirial", &virial);
+    plumed_cmd(plumedmain, "setVirial", &virial[0]);
 
     // Calculate the forces and energy.
 

--- a/platforms/opencl/src/OpenCLPlumedKernels.cpp
+++ b/platforms/opencl/src/OpenCLPlumedKernels.cpp
@@ -195,7 +195,7 @@ void OpenCLCalcPlumedForceKernel::executeOnWorkerThread() {
         plumed_cmd(plumedmain, "setBox", &boxVectors[0][0]);
     }
     double virial[9];
-    plumed_cmd(plumedmain, "setVirial", &virial);
+    plumed_cmd(plumedmain, "setVirial", &virial[0]);
 
     // Calculate the forces and energy.
 

--- a/platforms/reference/src/ReferencePlumedKernels.cpp
+++ b/platforms/reference/src/ReferencePlumedKernels.cpp
@@ -152,7 +152,7 @@ double ReferenceCalcPlumedForceKernel::execute(ContextImpl& context, bool includ
         plumed_cmd(plumedmain, "setBox", &boxVectors[0][0]);
     }
     double virial[9];
-    plumed_cmd(plumedmain, "setVirial", &virial);
+    plumed_cmd(plumedmain, "setVirial", &virial[0]);
 
     // Calculate the forces and energy.
 


### PR DESCRIPTION
Recent plumed versions (>=2.8) do typechecking on the arguments passed to the `plumed_cmd` function.

```
plumed_cmd(plumedmain, "setVirial", XX);
```
expects XX to be convertible to `const double*`. The type of `&virial` is `void*` instead (though referring to the same memory location).

To avoid false errors, `&virial` should be replaced with `&virial[0]`. Actually, `virial` would work as well.

See [this](https://groups.google.com/d/msgid/plumed-users/463a756c-4f08-4f59-a653-2bb967c79be8n%40googlegroups.com) thread on the PLUMED forum.