### PR TITLE
Don't assume SSE is present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ SET (CMAKE_CXX_STANDARD 11)
 # Set flags for linking on mac
 IF(APPLE)
     SET (CMAKE_INSTALL_NAME_DIR "@rpath")
-    SET(EXTRA_COMPILE_FLAGS "-msse2 -stdlib=libc++")
+    SET(EXTRA_COMPILE_FLAGS "-stdlib=libc++")
 ENDIF(APPLE)
 
 # Select where to install


### PR DESCRIPTION
This fixes an error building conda packages on ARM Macs.