### PR TITLE
Deactivating the c++ and fortran bindings in the PLUMED wrapper

### DIFF
--- a/openmmapi/include/internal/PlumedForceImpl.h
+++ b/openmmapi/include/internal/PlumedForceImpl.h
@@ -35,6 +35,8 @@
 #include "PlumedForce.h"
 #include "openmm/internal/ContextImpl.h"
 #include "openmm/internal/CustomCPPForceImpl.h"
+#define __PLUMED_WRAPPER_FORTRAN 0
+#define __PLUMED_WRAPPER_CXX 0
 #include "wrapper/Plumed.h"
 #include <utility>
 #include <set>


### PR DESCRIPTION
Hi!

I implemented the changes I was suggesting in #100.
I managed to reproduce the problem with no special setup also on my WSL machine (Ubuntu + gcc 11.4).

The `#define __PLUMED_WRAPPER_CXX 0` solves the problem, since it blocks the C++ interface

I also throw in `#define __PLUMED_WRAPPER_FORTRAN 0` to be sure to not emit that and remove some lifting from the compiler.

I think I should also add `#define __PLUMED_HAS_DLOPEN`, since that can be assumed true, due to using the wrapper in a context where python is loading modules from shared objects. I am asking about that to people more expert than me on this to be sure about that.

I should open a discussion on suggesting you to use the C++ interface instead of the C one. So you can also benefit of the size checks.
